### PR TITLE
プルダウン選択時、選択したページの表示実装

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,7 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background-color: #e1eafc;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,11 @@
     transform: rotate(360deg);
   }
 }
+
+.App-select {
+  position: fixed;
+  top: 5px;
+  left: 5px;
+  z-index: 10;
+  font-size: 0.9em;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,21 @@
+import { useState } from "react";
 import logo from './logo.svg';
 import './App.css';
 
-const App = () => {
-
+const App = ({ practices }) => {
   return (
     <div className="App">
       <header className="App-header">
-
+        <select className="App-select">
+          {practices.map((name, index) => (
+            <option key={name} value={index}>
+              {name}
+            </option>
+          ))}
+        </select>
       </header>
     </div>
   );
-}
+};
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,35 @@
-import { useState } from "react";
+import { useState, lazy, Suspense, useEffect } from 'react';
 import './App.css';
 
-const App = ({ practices }) => {
-  const [practiceIndex, setPracticeIndex] = useState(0);
+const Loader = ({ practice }) => {
+  // lazyをコンポーネントの外部で呼び出し、遅延読み込みされるReactコンポーネントを宣言
+  const LazyComponent = lazy(() => import(`./${practice}`));
 
+  return (
+    // Suspenseはコンポーネント内で非同期な操作完了するまで、ローディング状態を管理（遅延）する
+    <Suspense fallback={<div>読み込み中...</div>}>
+      <LazyComponent />
+    </Suspense>
+  );
+};
+
+const App = ({ practices }) => {
+  let restoredLecIndx = 0;
+  restoredLecIndx = restoredLecIndx < practices.length ? restoredLecIndx : 0;
+  const [practiceIndex, setPracticeIndex] = useState(restoredLecIndx);
+
+  // practice.jsの配列のページ名を取得
+  const practiceName = practices[practiceIndex];
+
+  // プルダウンからページ名を選択すると発火
   const contentChange = (e) => {
-    setPracticeIndex(e.target.value)
-  }
+    setPracticeIndex(e.target.value);
+  };
+
+  // useEffectは関数の実行タイミングをReactのレンダリング後まで遅らせるhook
+  // useEffectの第一引数は関数、第二引数は配列
+  // setItemのメソッドの引数（keyName: string, keyValue: string）
+  useEffect(() => localStorage.setItem('items', JSON.stringify(practiceIndex)),[practiceIndex]);
 
   return (
     <div className="App">
@@ -18,6 +41,9 @@ const App = ({ practices }) => {
             </option>
           ))}
         </select>
+        <div className="App-content">
+          <Loader practice={`${practiceName}`} />
+        </div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,12 @@
 import logo from './logo.svg';
 import './App.css';
 
-function App() {
+const App = () => {
+
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,17 @@
 import { useState } from "react";
-import logo from './logo.svg';
 import './App.css';
 
 const App = ({ practices }) => {
+  const [practiceIndex, setPracticeIndex] = useState(0);
+
+  const contentChange = (e) => {
+    setPracticeIndex(e.target.value)
+  }
+
   return (
     <div className="App">
       <header className="App-header">
-        <select className="App-select">
+        <select className="App-select" value={practiceIndex} onChange={contentChange}>
           {practices.map((name, index) => (
             <option key={name} value={index}>
               {name}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
+import practices from "./practices";
 import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <App practices={practices}/>
   </React.StrictMode>
 );
 

--- a/src/practices.js
+++ b/src/practices.js
@@ -1,5 +1,6 @@
 const practices = [
-    "todo_with_useState"
+    "todo_with_useState",
+    "todo_with_useReducer"
 ]
     
 export default practices;

--- a/src/practices.js
+++ b/src/practices.js
@@ -1,0 +1,5 @@
+const practices = [
+    "todo_with_useState"
+]
+    
+export default practices;

--- a/src/todo_with_useReducer.js
+++ b/src/todo_with_useReducer.js
@@ -1,0 +1,10 @@
+
+const todoReducer = () => {
+    return(
+        <>
+            <h1>todo_with_useReducer</h1>
+        </>
+    )
+}
+
+export default todoReducer

--- a/src/todo_with_useState.js
+++ b/src/todo_with_useState.js
@@ -1,0 +1,10 @@
+
+const todoState = () => {
+    return(
+        <>
+            <h1>todo_with_useState</h1>
+        </>
+    )
+}
+
+export default todoState


### PR DESCRIPTION
・index.jsのReactDOMの記述短縮し、App.jsに渡すpropsを追加
・背景色を薄い青色に修正
・practice.jsを追加し、表示したいページ名を配列の中に定義
・propsを受け取りプルダウンで表示する機能追加
・プルダウン選択時、選択したページを読み込み表示する機能を追加
→ useState、useEffect、lazy、Suspenseを使用して実装